### PR TITLE
#4 tailwind.config에 스타일 가이드 반영

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -69,6 +71,8 @@
 @layer base {
   * {
     @apply border-border;
+    font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+    font-size: 62.5%;
   }
   body {
     @apply bg-background text-foreground;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,7 @@ module.exports = {
 				"2xl": "1400px",
 			},
 		},
+		fontFamily: {},
 		extend: {
 			colors: {
 				border: "hsl(var(--border))",
@@ -23,34 +24,75 @@ module.exports = {
 				ring: "hsl(var(--ring))",
 				background: "hsl(var(--background))",
 				foreground: "hsl(var(--foreground))",
-				primary: {
-					DEFAULT: "hsl(var(--primary))",
-					foreground: "hsl(var(--primary-foreground))",
+				/** main-50과 같은 방식으로 사용 */
+				main: {
+					50: "#EEF2FF",
+					100: "#E0E7FF",
+					200: "#C7D2FE",
+					300: "#A5B4FC",
+					400: "#818CF8",
+					500: "#6366F1",
+					600: "#4F46E5",
+					700: "#4338CA",
+					800: "#3730A3",
+					900: "#312E81",
+					950: "#1E1B4B",
 				},
-				secondary: {
-					DEFAULT: "hsl(var(--secondary))",
-					foreground: "hsl(var(--secondary-foreground))",
+				zinc: {
+					50: "#FAFAFA",
+					100: "#F4F4F5",
+					200: "#E4E4E7",
+					300: "#D4D4D8",
+					400: "#A1A1AA",
+					500: "#71717A",
 				},
-				destructive: {
-					DEFAULT: "hsl(var(--destructive))",
-					foreground: "hsl(var(--destructive-foreground))",
+				gray: {
+					50: "#F9FAFB",
+					100: "#F3F4F6",
+					200: "#E5E7EB",
+					300: "#D1D5DB",
+					400: "#9CA3AF",
+					500: "#6B7280",
+					600: "#4B5563",
+					700: "#374151",
+					800: "#1F2937",
+					900: "#111827",
+					950: "#030712",
 				},
-				muted: {
-					DEFAULT: "hsl(var(--muted))",
-					foreground: "hsl(var(--muted-foreground))",
+				bg: {
+					primary: "#FFFFFF",
+					secondary: "#F4F4FA",
 				},
-				accent: {
-					DEFAULT: "hsl(var(--accent))",
-					foreground: "hsl(var(--accent-foreground))",
+				sub: {
+					white: "#FFFFFF",
+					black: "#000000",
+					red: "#FF3B30",
+					yellow: "#FFCC00",
+					green: "#34C759",
+					blue: "#007AFF",
 				},
-				popover: {
-					DEFAULT: "hsl(var(--popover))",
-					foreground: "hsl(var(--popover-foreground))",
-				},
-				card: {
-					DEFAULT: "hsl(var(--card))",
-					foreground: "hsl(var(--card-foreground))",
-				},
+			},
+			/** 스타일 가이드의 effect 부분(1,2,3,4)
+			 * shadow-1,2,3,4와 같은식으로 사용
+			 */
+			boxShadow: {
+				1: "0px 4px 4px 0px rgba(142, 141, 208, 0.16)",
+				2: "0 4px 8px 0px rgb(142, 141, 208, 0.16)",
+				3: "0px 8px 16px 0px rgba(142, 141, 208, 0.12)",
+				4: "0 16px 24px 0px rgba(142, 141, 208, 0.12)",
+			},
+			/** 스타일 가이드의 폰트 부분
+			 * text-카테고리-사이즈 식으로 사용
+			 */
+			fontSize: {
+				"title-lg": ["48px", { fontWeight: "600", lineHeight: "72px" }],
+				"title-md": ["36px", { fontWeight: "600", lineHeight: "52px" }],
+				"title-sm": ["24px", { fontWeight: "600", lineHeight: "38px" }],
+				"text-xl": ["20px", { fontWeight: "600", lineHeight: "32px" }],
+				"text-lg": ["18px", { fontWeight: "500", lineHeight: "30px" }],
+				"text-md": ["16px", { fontWeight: "400", lineHeight: "24px" }],
+				"text-sm": ["14px", { fontWeight: "400", lineHeight: "20px" }],
+				"text-xs": ["12px", { fontWeight: "400", lineHeight: "16px" }],
 			},
 			borderRadius: {
 				lg: "var(--radius)",


### PR DESCRIPTION
[구체적인 사용방법]
https://www.notion.so/tailwind-config-51b1e035992e4853bf3e1d44a686dcf1

[건의사항]
우선 index.css가 tailwind base등을 가져오는 구간이라 global.css로 인지하고 있습니다.
- 어차피 폰트 스타일은 Pretendard를 사용할 것 같아 index.css에서 가변 다이나믹 폰트로 import하였습니다.
- px, rem에 대한 것도 한번 상의해봐야될 것 같은데 index.css에서 일단은 font-size : 62.5% 로 10px 기준으로 rem단위로 맞춰놨습니다.
- UI작업하면서 (기본적으로 tailwind 클래스가 어느정도 지정해주겠지만) 제공되는 값이 아닐경우 rem을 사용할건지, px을 사용할지는 한번 상의 해봐야겠습니다.