### PR TITLE
사이드바 및 서브헤더 UI구현 및 admin 메인 화면 현재 코드와 병합

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		]
 	},
 	"dependencies": {
+		"@radix-ui/react-accordion": "^1.1.2",
 		"@radix-ui/react-dropdown-menu": "^2.0.6",
 		"@radix-ui/react-separator": "^1.0.3",
 		"@radix-ui/react-slot": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@radix-ui/react-accordion':
+    specifier: ^1.1.2
+    version: 1.1.2(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-dropdown-menu':
     specifier: ^2.0.6
     version: 2.0.6(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0)
@@ -807,6 +810,35 @@ packages:
       '@babel/runtime': 7.24.0
     dev: false
 
+  /@radix-ui/react-accordion@1.1.2(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-fDG7jcoNKVjSK6yfmuAs0EnPDro0WMXIhMtXdTBWqEioVW206ku+4Lw07e+13lUkFkpoEQ2PdeMIAGpdqEAmDg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.0
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collapsible': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.63)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.63)(react@18.2.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.2.63)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.63)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.63)(react@18.2.0)
+      '@types/react': 18.2.63
+      '@types/react-dom': 18.2.19
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-arrow@1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==}
     peerDependencies:
@@ -822,6 +854,34 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.63
+      '@types/react-dom': 18.2.19
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-collapsible@1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-UBmVDkmR6IvDsloHVN+3rtx4Mi5TFvylYXpluuv0f37dtaz3H99bp8No0LGXRigVpl3UAT4l9j6bIchh42S/Gg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.24.0
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.63)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.63)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.63)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.19)(@types/react@18.2.63)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.63)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.2.63)(react@18.2.0)
       '@types/react': 18.2.63
       '@types/react-dom': 18.2.19
       react: 18.2.0

--- a/src/core/workspace/ui/MemberDropDown.tsx
+++ b/src/core/workspace/ui/MemberDropDown.tsx
@@ -1,11 +1,22 @@
 import {
 	DropdownMenu,
 	DropdownMenuContent,
-	DropdownMenuLabel,
 	DropdownMenuTrigger,
 } from "@/lib/ui/dropdown-menu";
-import { Users, ChevronDown, ChevronUp } from "lucide-react";
+import { Users, ChevronDown, ChevronUp, User } from "lucide-react";
 import { useState } from "react";
+
+/** @TODO 데이터 받아오면 넣기 + 이미지 존재하면 분기 설정 */
+function MemberDropDownItem() {
+	return (
+		<li className="flex items-center gap-3 w-full py-2 pl-3 text-text-xs">
+			<span className="flex justify-center items-center rounded-full bg-zinc-200 w-6 h-6">
+				<User className="text-zinc-400 w-4 h-4" />
+			</span>
+			멤버 이름
+		</li>
+	);
+}
 
 function MemberDropDown() {
 	const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -30,8 +41,17 @@ function MemberDropDown() {
 					</div>
 				</button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent>
-				<DropdownMenuLabel>여기 멤버 들어갈듯</DropdownMenuLabel>
+			<DropdownMenuContent className="bg-bg-primary">
+				<ul className="w-[170px] h-[200px] overflow-auto">
+					{/** @TODO 데이터 받아오면 map */}
+					<MemberDropDownItem />
+					<MemberDropDownItem />
+					<MemberDropDownItem />
+					<MemberDropDownItem />
+					<MemberDropDownItem />
+					<MemberDropDownItem />
+					<MemberDropDownItem />
+				</ul>
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/src/core/workspace/ui/SideBar.tsx
+++ b/src/core/workspace/ui/SideBar.tsx
@@ -1,3 +1,4 @@
+import WorkspaceAccordion from "@/core/workspace/ui/WorkspaceAccordion";
 import { useEffect, useState } from "react";
 
 type SideBarProps = {
@@ -25,7 +26,7 @@ function SideBar({ isOpen }: SideBarProps) {
 				isOpen ? "hidden" : "flex"
 			} transition-all ease-out fixed z-10 w-[203px] inset-y-0 rounded-[20px] py-[14px] px-[11px] bg-bg-primary shadow-4`}
 		>
-			사이드바
+			<WorkspaceAccordion />
 		</aside>
 	);
 }

--- a/src/core/workspace/ui/SideBar.tsx
+++ b/src/core/workspace/ui/SideBar.tsx
@@ -24,8 +24,9 @@ function SideBar({ isOpen }: SideBarProps) {
 			style={{ left: `${distance}px` }}
 			className={`${
 				isOpen ? "hidden" : "flex"
-			} transition-all ease-out fixed z-10 w-[203px] inset-y-0 rounded-[20px] py-[14px] px-[11px] bg-bg-primary shadow-4`}
+			} flex-col gap-[14px] transition-all ease-out fixed z-10 w-[203px] inset-y-0 rounded-[20px] py-[14px] px-[11px] bg-bg-primary shadow-4`}
 		>
+			<span>검색하기</span>
 			<WorkspaceAccordion />
 		</aside>
 	);

--- a/src/core/workspace/ui/SideBar/SearchBar.tsx
+++ b/src/core/workspace/ui/SideBar/SearchBar.tsx
@@ -1,0 +1,16 @@
+import { Search } from "lucide-react";
+
+/** @TODO 데이터 들어오면 검색어 필터링 기능 추가 */
+function SearchBar() {
+	return (
+		<div className="relative w-full ">
+			<input
+				className="w-full h-9 pl-[41px] px-2.5 rounded-[5px] text-text-xs font-semibold bg-zinc-100 outline-none placeholder:text-zinc-400"
+				placeholder="검색하기"
+			/>
+			<Search className="w-5 h-5 absolute top-2 left-2 text-zinc-400" />
+		</div>
+	);
+}
+
+export default SearchBar;

--- a/src/core/workspace/ui/SideBar/SideBar.tsx
+++ b/src/core/workspace/ui/SideBar/SideBar.tsx
@@ -1,4 +1,6 @@
-import WorkspaceAccordion from "@/core/workspace/ui/WorkspaceAccordion";
+import SearchBar from "@/core/workspace/ui/SideBar/SearchBar";
+import WorkspaceAccordion from "@/core/workspace/ui/SideBar/WorkspaceAccordion";
+import { ListPlus } from "lucide-react";
 import { useEffect, useState } from "react";
 
 type SideBarProps = {
@@ -26,8 +28,17 @@ function SideBar({ isOpen }: SideBarProps) {
 				isOpen ? "hidden" : "flex"
 			} flex-col gap-[14px] transition-all ease-out fixed z-10 w-[203px] inset-y-0 rounded-[20px] py-[14px] px-[11px] bg-bg-primary shadow-4`}
 		>
-			<span>검색하기</span>
+			<SearchBar />
 			<WorkspaceAccordion />
+			<div className="flex gap-2 items-center text-zinc-400 text-text-xs font-semibold">
+				<ListPlus /> 워크스페이스 추가
+			</div>
+			<div className="text-zinc-400 text-text-xs font-semibold pl-[30px]">
+				워크스페이스 생성하기
+			</div>
+			<div className="text-zinc-400 text-text-xs font-semibold pl-[30px]">
+				초대 받은 워크스페이스
+			</div>
 		</aside>
 	);
 }

--- a/src/core/workspace/ui/SideBar/WorkspaceAccordion.tsx
+++ b/src/core/workspace/ui/SideBar/WorkspaceAccordion.tsx
@@ -34,16 +34,16 @@ function WorkspaceAccordion() {
 				</AccordionTrigger>
 				<AccordionContent>
 					{/** @TODO map사용해야함. 클릭시 workspaceId로 이동하도록 추가해야함 */}
-					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs">
+					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs font-semibold">
 						워크스페이스 1
 					</div>
-					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs">
+					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs font-semibold">
 						워크스페이스 2
 					</div>
-					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs">
+					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs font-semibold">
 						워크스페이스 3
 					</div>
-					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs">
+					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs font-semibold">
 						워크스페이스 4
 					</div>
 				</AccordionContent>

--- a/src/core/workspace/ui/SideBar/WorkspaceAccordion.tsx
+++ b/src/core/workspace/ui/SideBar/WorkspaceAccordion.tsx
@@ -5,7 +5,7 @@ import {
 	AccordionTrigger,
 } from "@/lib/ui/accordion";
 import { ChevronDown, List } from "lucide-react";
-import { useState, type MouseEvent } from "react";
+import { useState } from "react";
 
 function WorkspaceAccordion() {
 	const [isOpen, setIsOpen] = useState<boolean>(true);
@@ -16,7 +16,7 @@ function WorkspaceAccordion() {
 			defaultValue="workspace-list"
 			collapsible
 			className="w-full"
-			onValueChange={(e: MouseEvent) => {
+			onValueChange={(e: string) => {
 				setIsOpen(!!e);
 			}}
 		>

--- a/src/core/workspace/ui/SubHeader.tsx
+++ b/src/core/workspace/ui/SubHeader.tsx
@@ -28,7 +28,7 @@ function SubHeader({
 					{workspaceData.name}
 				</div>
 				<div className="flex items-center gap-[21px]">
-					{<MemberDropDown />}
+					<MemberDropDown />
 					<Link
 						to="/workspaces/$workspaceId/admin"
 						params={{ workspaceId: workspaceData.id }}

--- a/src/core/workspace/ui/WorkspaceAccordion.tsx
+++ b/src/core/workspace/ui/WorkspaceAccordion.tsx
@@ -4,18 +4,49 @@ import {
 	AccordionItem,
 	AccordionTrigger,
 } from "@/lib/ui/accordion";
+import { ChevronDown, List } from "lucide-react";
+import { useState, type MouseEvent } from "react";
 
 function WorkspaceAccordion() {
+	const [isOpen, setIsOpen] = useState<boolean>(true);
+
 	return (
 		<Accordion
 			type="single"
-			defaultValue="item-1"
+			defaultValue="workspace-list"
 			collapsible
 			className="w-full"
+			onValueChange={(e: MouseEvent) => {
+				setIsOpen(!!e);
+			}}
 		>
-			<AccordionItem value="item-1">
-				<AccordionTrigger>테스트</AccordionTrigger>
-				<AccordionContent>내용물</AccordionContent>
+			<AccordionItem value="workspace-list">
+				<AccordionTrigger
+					className={`${
+						isOpen && "bg-bg-secondary"
+					} rounded-[5px] p-[7px] hover:no-underline`}
+				>
+					<div className="flex items-center gap-2 text-main-600 text-text-xs font-semibold">
+						<List />
+						워크스페이스 목록
+					</div>
+					<ChevronDown className="h-6 w-6 text-main-600 shrink-0 transition-transform duration-200" />
+				</AccordionTrigger>
+				<AccordionContent>
+					{/** @TODO map사용해야함. 클릭시 workspaceId로 이동하도록 추가해야함 */}
+					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs">
+						워크스페이스 1
+					</div>
+					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs">
+						워크스페이스 2
+					</div>
+					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs">
+						워크스페이스 3
+					</div>
+					<div className="flex items-center p-1.5 text-zinc-400 text-text-xs">
+						워크스페이스 4
+					</div>
+				</AccordionContent>
 			</AccordionItem>
 		</Accordion>
 	);

--- a/src/core/workspace/ui/WorkspaceAccordion.tsx
+++ b/src/core/workspace/ui/WorkspaceAccordion.tsx
@@ -1,0 +1,24 @@
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from "@/lib/ui/accordion";
+
+function WorkspaceAccordion() {
+	return (
+		<Accordion
+			type="single"
+			defaultValue="item-1"
+			collapsible
+			className="w-full"
+		>
+			<AccordionItem value="item-1">
+				<AccordionTrigger>테스트</AccordionTrigger>
+				<AccordionContent>내용물</AccordionContent>
+			</AccordionItem>
+		</Accordion>
+	);
+}
+
+export default WorkspaceAccordion;

--- a/src/lib/ui/accordion.tsx
+++ b/src/lib/ui/accordion.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Accordion = AccordionPrimitive.Root;
+
+const AccordionItem = React.forwardRef<
+	React.ElementRef<typeof AccordionPrimitive.Item>,
+	React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+	<AccordionPrimitive.Item
+		ref={ref}
+		className={cn("border-b", className)}
+		{...props}
+	/>
+));
+AccordionItem.displayName = "AccordionItem";
+
+const AccordionTrigger = React.forwardRef<
+	React.ElementRef<typeof AccordionPrimitive.Trigger>,
+	React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+	<AccordionPrimitive.Header className="flex">
+		<AccordionPrimitive.Trigger
+			ref={ref}
+			className={cn(
+				"flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			<ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
+		</AccordionPrimitive.Trigger>
+	</AccordionPrimitive.Header>
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
+
+const AccordionContent = React.forwardRef<
+	React.ElementRef<typeof AccordionPrimitive.Content>,
+	React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+	<AccordionPrimitive.Content
+		ref={ref}
+		className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+		{...props}
+	>
+		<div className={cn("pb-4 pt-0", className)}>{children}</div>
+	</AccordionPrimitive.Content>
+));
+
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/src/lib/ui/accordion.tsx
+++ b/src/lib/ui/accordion.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { ChevronDown } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -32,7 +31,6 @@ const AccordionTrigger = React.forwardRef<
 			{...props}
 		>
 			{children}
-			<ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
 		</AccordionPrimitive.Trigger>
 	</AccordionPrimitive.Header>
 ));

--- a/src/pages/workspaces/_workspaceLayout.$workspaceId.admin.tsx
+++ b/src/pages/workspaces/_workspaceLayout.$workspaceId.admin.tsx
@@ -1,4 +1,7 @@
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/lib/ui/tabs";
 import { createFileRoute } from "@tanstack/react-router";
+import { UserRoundCogIcon, FileLock2Icon } from "lucide-react";
+import WorkspaceAdminContent from "@/core/workspace/ui/AdminContent";
 
 export const Route = createFileRoute(
 	"/workspaces/_workspaceLayout/$workspaceId/admin",
@@ -7,8 +10,36 @@ export const Route = createFileRoute(
 });
 
 function WorkSpaceIdAdminPageComponents() {
-	const { workspaceId } = Route.useParams();
-	return <div>워크스페이스 {workspaceId} admin 페이지</div>;
+	return (
+		<main className="p-[36px] max-w-[1084px]">
+			<Tabs defaultValue="workspace">
+				<TabsList>
+					<TabsTrigger value="workspace" className="flex gap-[4px]">
+						<UserRoundCogIcon
+							width={18}
+							height={18}
+							className="h-[1.125rem] w-[1.125rem]"
+						/>
+						멤버 및 워크스페이스 설정
+					</TabsTrigger>
+					<TabsTrigger value="credential" className="flex gap-[4px]">
+						<FileLock2Icon
+							width={18}
+							height={18}
+							className="h-[1.125rem] w-[1.125rem]"
+						/>
+						권한 설정
+					</TabsTrigger>
+				</TabsList>
+				<TabsContent value="workspace" className="mt-0 pt-[36px]">
+					<WorkspaceAdminContent />
+				</TabsContent>
+				<TabsContent value="credential" className="mt-0 pt-[36px]">
+					권한 설정
+				</TabsContent>
+			</Tabs>
+		</main>
+	);
 }
 
 export default WorkSpaceIdAdminPageComponents;

--- a/src/pages/workspaces/_workspaceLayout.tsx
+++ b/src/pages/workspaces/_workspaceLayout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, createFileRoute, getRouteApi } from "@tanstack/react-router";
 import { useState } from "react";
 import SubHeader from "@/core/workspace/ui/SubHeader";
-import SideBar from "@/core/workspace/ui/SideBar";
+import SideBar from "@/core/workspace/ui/SideBar/SideBar";
 
 export const Route = createFileRoute("/workspaces/_workspaceLayout")({
 	component: WorkSpaceLayoutComponent,

--- a/src/pages/workspaces/_workspaceLayout.tsx
+++ b/src/pages/workspaces/_workspaceLayout.tsx
@@ -20,7 +20,7 @@ function WorkSpaceLayoutComponent() {
 	return (
 		<>
 			<SideBar isOpen={!isOpen} />
-			<div className="bg-bg-secondary h-[100vh]">
+			<div className="bg-bg-secondary min-h-[100vh]">
 				<SubHeader
 					isOpen={isOpen}
 					onClickChevronButton={handleToggleSidebar}


### PR DESCRIPTION

https://github.com/golapadeok/fluo-fe/assets/56223156/39b9fbdd-5a9a-44a3-b639-63fd584baee1


https://github.com/golapadeok/fluo-fe/assets/56223156/d535965e-4411-4f49-8852-25240673e29b

- 데이터 들어와야되는 구간 제외하고 만들었습니다(map등으로 활용해야 하는 부분도 일단 하드코딩 해놓음)
- 데이터 활용하는 구간은 `@TODO` 로 주석에 적어놨음.
- 용준님이 만드신 admin 탭 부분은 라우팅 된 페이지에 코드 그대로 옮겨와서 병합했습니다.(2번 영상 부분)
- 혹시 몰라 원래 파일은 삭제 안했음